### PR TITLE
feat: Use the style action every time it is updated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,17 @@
 import type { Properties } from 'csstype';
 
 const style = (node: HTMLElement, parameters: Properties<string | number>) => {
-  Object.entries(parameters).forEach(([key, value]) => {
-    key = key.replace(/[A-Z]/, (substring) => '-' + substring.toLowerCase());
+  function update (parameters: Properties<string | number>) {
+    Object.entries(parameters).forEach(([key, value]) => {
+      key = key.replace(/[A-Z]/, (substring) => '-' + substring.toLowerCase());
 
-    node.style.setProperty(key, value);
-  });
+      node.style.setProperty(key, value);
+    });
+  }
+
+  update(parameters); // invoked when component is first mounted
+
+  return { update } // to be invoked whenever component is updated
 };
 
 export default style;


### PR DESCRIPTION
I like the idea of using svelte Actions in order to apply inline styles to an HTML element directly.

However, the current version only applies styles when a component gets mounted, i.e., when an HTML element is created.

My simple change allows the style action also to be used whenever the associated component is updated.

Hope, you find it useful.

With greetings from Germany,

Andreas Rozek